### PR TITLE
➕Add `pytest-datafiles` as dependency to the tests (+coverage+dev) env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands = python -m pip install --upgrade pip
 deps =
     -rrequirements.txt
     pytest
+    pytest-datafiles
 setenv = PYTHONPATH = {toxinidir}/src
 commands = python -m pytest --basetemp={envtmpdir} {posargs}
 


### PR DESCRIPTION
https://github.com/omarkohl/pytest-datafiles

nach dem mergen einmal mit tox -re neu aufbauen die betroffenen umgebungen.